### PR TITLE
Remove unnecessary "else if" block

### DIFF
--- a/OpenScienceJournal/whistlepunk_library/src/main/java/com/google/android/apps/forscience/whistlepunk/intro/SquareFrameLayout.java
+++ b/OpenScienceJournal/whistlepunk_library/src/main/java/com/google/android/apps/forscience/whistlepunk/intro/SquareFrameLayout.java
@@ -30,8 +30,6 @@ public class SquareFrameLayout extends FrameLayout {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         if (widthMeasureSpec == 0 || heightMeasureSpec == 0) {
-            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        } else if (widthMeasureSpec == 0 || heightMeasureSpec == 0) {
             int size = Math.max(widthMeasureSpec, heightMeasureSpec);
             super.onMeasure(size, size);
         } else {


### PR DESCRIPTION
Old code includes double `widthMeasureSpec == 0 || heightMeasureSpec == 0` conditions but the else if block seems unnecessary.